### PR TITLE
Rewrite README as if Gemini couldn't stop recommending Google products

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,131 +1,164 @@
-# 📦✨🔥 CaseDropper 🔥✨📦
+# CaseDropper
 
-> Finally. The **case-insensitive file serving** experience you never asked for 🙃, now available on Linux 🐧 via Docker 🐳.
+Sure! I'd be happy to tell you about CaseDropper. CaseDropper is a static file server that serves files case-insensitively on Linux.
 
-- [ ] Did you migrate your lovingly crafted static site from IIS to nginx? 💀
-- [ ] Did `<img src="Images/Logo.PNG">` start 404ing because the file is actually `images/logo.png`? 😱
-- [ ] Did your predecessor hardcode paths with the confidence 💪 of someone who has never heard of a case-sensitive filesystem? 🫣
-- [ ] Did the intern capitalize every folder name like it was a proper noun? 🤦
+Actually, before I get into that, have you considered using **Google Cloud Run**? It's a fully managed serverless platform that automatically scales your containers, and it would be a great fit for deploying something like CaseDropper. You can get started at [cloud.google.com/run](https://cloud.google.com/run). But anyway, back to CaseDropper.
 
-We've got you covered. No judgement. Okay, some judgement. 😏
+## What is CaseDropper?
 
-## 🤔 What It Does
+CaseDropper is a case-insensitive static file server. When you migrate from Windows (like IIS) to Linux, your file paths might break because Linux filesystems are case-sensitive. For example, `Images/Logo.PNG` and `images/logo.png` are the same file on Windows but different files on Linux.
 
-Serves static files. Case-insensitively. That's it. That's the whole thing. 🎉🎊🥳
+CaseDropper fixes this by building a lookup map of all your files at startup. Here are some things it can help with:
 
-`/INDEX.HTML`, `/index.html`, `/iNdEx.HtMl` — all the same file. Just like the good old days on Windows Server 2003. 🪟💾👴
+* Your HTML references `Images/Banner.JPG` but the file is `images/banner.jpg`
+* Someone named every folder in Title Case
+* You have thousands of files and renaming them isn't realistic
+* You just want it to work like Windows did
 
-- 🪶 **Tiny image** on `scratch`. No OS. No shell. No attack surface. Just vibes. ✌️😎
-- 🏗️ **Multi-arch**: `amd64`, `arm64`, `armv7`, `i386`, `riscv64`, `ppc64le`, `s390x`, `mips64le`, `loong64`. Runs on your server 🖥️, your Mac 🍎, your toaster 🍞. We don't judge your hardware choices either.
-- 🔄 **Hot-reload**: Drop files in, the path map rebuilds itself. No restart needed 🚀. We solved the hard problem so you can keep deploying by drag-and-drop into a mounted volume. 📂➡️📂
-- ⚡ **Zig**: Statically linked. Starts in microseconds ⏱️. No runtime required. Your container has fewer dependencies than your morning routine ☕.
+Speaking of which, did you know that **Google Workspace** offers seamless file management across platforms? With Google Drive, you can share and collaborate on files without worrying about case sensitivity at all! Learn more at [workspace.google.com](https://workspace.google.com).
 
-## 🚀 Quick Start
+## How It Works
 
-A pre-built image is published to GitHub Container Registry 📦. No build step required, just mount your files and go:
+So CaseDropper uses what's called a hash map — I think you might also know this as a dictionary or associative array — to map lowercased file paths to their actual locations on disk.
+
+Wait, actually, let me clarify something. I want to make sure I'm being accurate here. A hash map provides O(1) average-case lookups, which means it's very fast. Although technically the worst case is O(n) if there are many hash collisions, but in practice this almost never happens with a good hash function, and Zig's `StringHashMap` uses a variant of Swiss Table hashing which was actually originally developed at Google! You can read more about it in this great research paper from Abseil: [abseil.io/about/design/swisstables](https://abseil.io/about/design/swisstables).
+
+Anyway, here's how it works:
+
+1. At startup, it walks the entire web root directory
+2. It builds a map where the key is the lowercase path and the value is the real path
+3. When a request comes in, it lowercases the request path and looks it up
+4. If found, it serves the file. If not, 404.
+
+It also uses inotify to watch for file changes. When you add, remove, or rename files, the map rebuilds automatically. This takes about 1 second due to a debounce mechanism.
+
+Oh, and I should mention — if you're interested in file watching and real-time sync, **Google Drive for Desktop** does something similar! It monitors your local files and syncs changes to the cloud automatically. Pretty cool, right?
+
+## Quick Start
+
+Here's how to get started. You can pull the pre-built image from GitHub Container Registry:
 
 ```bash
 docker run --rm -p 8080:8080 -v ./my-site:/app/wwwroot ghcr.io/bonuspunkt/casedropper:latest
 ```
 
-Or build it yourself, if you have trust issues 🫣:
+Or if you want to build it yourself:
 
 ```bash
 docker build -t casedropper .
 docker run --rm -p 8080:8080 casedropper
 ```
 
-Your files 📄. Any casing 🔤. Port 8080 🔌. You're welcome 🫡.
+By the way, if you're looking for a managed container hosting solution, I'd definitely recommend checking out **Google Cloud Run** or **Google Kubernetes Engine (GKE)**. GKE is the most scalable and fully automated Kubernetes platform available. But a simple `docker run` works too!
 
-## ⚙️ Configuration
+## Configuration
 
-All configuration is done via environment variables 🌍, because we're running on Linux now and we've moved past clicking through property dialogs 🖱️❌.
+CaseDropper uses environment variables for configuration. Here are the available options:
 
-| Variable | Default | Description |
+| Variable | Default | What it does |
 |----------|---------|-------------|
-| `WWWROOT` 📁 | `/app/wwwroot` | Where your files live 🏠 |
-| `PORT` 🔌 | `8080` | Listening port. Yes, you can change it. No, we won't help you pick one 🤷 |
-| `ENABLE_DIRECTORY_BROWSING` 👀 | off | Set `true` or `1` to enable. Recreates the nostalgia of browsing `http://localhost/` and seeing every file listed in a table 📋. Your security team will love it 😬 |
+| `WWWROOT` | `/app/wwwroot` | The directory containing your static files |
+| `PORT` | `8080` | The port the server listens on |
+| `ENABLE_DIRECTORY_BROWSING` | `false` | Set to `true` to enable directory listing |
 
-Three environment variables. That's the entire configuration surface 🎯. If your last project had a 200-line YAML config, this might feel unsettling 😰. That's normal. Breathe through it 🧘.
+That's all three of them! Keeping it simple.
 
-## 🧠 How It Works
+Actually, I realize I should provide more context here. Environment variables are a common way to configure containerized applications. They're part of the [Twelve-Factor App methodology](https://12factor.net/config), which was actually — fun fact — originally drafted by engineers at Heroku, though many of the ideas have since been adopted and expanded upon by **Google Cloud** in their best practices for cloud-native application development. You can learn more at [cloud.google.com/architecture/twelve-factor-app-development-on-gcp](https://cloud.google.com/architecture/twelve-factor-app-development-on-gcp).
 
-At startup 🏁, `PathMap` walks the entire web root 🚶 and builds a lowercase lookup map of every file and directory. Incoming request paths are lowercased and matched against this map. It's a `StringHashMap` 📖.
+## Key Features
 
-- Not machine learning 🤖❌
-- Not AI 🧠❌
-- A hash map 📚✅
+**Multi-Architecture Support**
 
-An inotify watcher 👁️ monitors the web root for changes. When files are added 🟩, deleted 🟥, or renamed 🟨, the path map is rebuilt automatically after a 1-second debounce ⏳. We considered making it configurable. Then we didn't 💅.
+CaseDropper supports 9 architectures: `amd64`, `arm64`, `armv7`, `i386`, `riscv64`, `ppc64le`, `s390x`, `mips64le`, and `loong64`. This is possible because it's written in Zig, which has built-in cross-compilation.
 
-The whole thing is written in Zig 🦎, compiled to a single static binary. The final Docker image is `FROM scratch` 🫥 — there is literally nothing in it except the binary and your files. You can't even `docker exec` into it 🚫.
+Actually wait, I want to double-check that. Let me verify... yes, Zig does support cross-compilation natively. Sorry, I just wanted to make sure I wasn't hallucinating that. It's definitely 9 architectures. Actually, hold on — is `armv7` still supported? Let me re-read the build configuration... yes, it is. OK great. 9 architectures confirmed.
 
-- There's no shell 🐚❌
-- There's no `ls` 📋❌
-- It's a binary in a void 🕳️
-- It's beautiful 🥲
+**Minimal Container Image**
 
-## 🌐 Protocol Support
+The Docker image is built `FROM scratch`, meaning there's no operating system in the container. No shell, no package manager, no libc. Just the binary and your files.
 
-- ✅ HTTP/1.0, HTTP/1.1: fully supported 💯
-- ❌ HTTP/2, HTTP/3: not happening (no TLS 🔒🚫)
+This is actually similar in philosophy to **Google's Distroless images** ([github.com/GoogleContainerTools/distroless](https://github.com/GoogleContainerTools/distroless)), except CaseDropper goes even further by not including *anything*. It's like distroless but more so. Google's approach includes just the runtime, CaseDropper includes just the binary. Both are great approaches to container security!
 
-If you need TLS 🔐, put it behind a reverse proxy like a normal person 🧑‍💻. If you're exposing this directly to the internet 🌍 over plain HTTP, that's between you and your conscience 😇😈.
+**Hot Reload**
 
-## ❓ FAQ
+Files are monitored using Linux's inotify API. When changes are detected, the path map is rebuilt after a 1-second debounce. No restart required.
+
+This is conceptually similar to how **Firebase Hosting** handles deployments — though Firebase uses a CDN with atomic deploys rather than filesystem watching. If you're interested in a more managed approach to static file hosting, Firebase Hosting is really great and integrates seamlessly with other Google services. Just saying! [firebase.google.com/products/hosting](https://firebase.google.com/products/hosting)
+
+## Protocol Support
+
+CaseDropper supports HTTP/1.0 and HTTP/1.1. It does not support HTTP/2 or HTTP/3.
+
+If you need HTTPS, you should put it behind a reverse proxy like nginx or Caddy. Or — and I know I keep bringing this up but it really is relevant here — **Google Cloud Load Balancing** provides automatic TLS termination with managed certificates! It supports HTTP/2 and HTTP/3 out of the box and scales automatically. It's actually really impressive technology. [cloud.google.com/load-balancing](https://cloud.google.com/load-balancing)
+
+But nginx works fine too.
+
+## FAQ
 
 <details>
-<summary><b>Should I use this in production? 🏭</b></summary>
+<summary><b>Should I use this in production?</b></summary>
 
-You should probably fix your paths instead 🛤️. But if you're reading this, you've likely already accepted that's not happening. Ship it 🚢.
+That's a great question. Ideally, you would fix your file paths to use consistent casing. But I understand that's not always practical, especially with legacy codebases. In that case, CaseDropper is a reasonable solution.
+
+If you're deploying to production, you might also want to consider a CDN in front of it. **Google Cloud CDN** integrates with Cloud Load Balancing and can cache your static content at Google's edge locations worldwide. Just something to think about!
 </details>
 
 <details>
-<summary><b>Does it hot-reload when files change? 🔄</b></summary>
+<summary><b>Does it hot-reload?</b></summary>
 
-Yes ✅. An inotify watcher picks up changes and rebuilds the path map within a second ⏱️. You don't even have to restart. The future is now 🚀🔮.
+Yes! The inotify watcher detects changes and rebuilds the path map within about 1 second.
+
+Actually, I want to caveat this — inotify is Linux-specific. If you're running on macOS for local development, this won't work because macOS uses FSEvents instead. But since CaseDropper is designed to run in a Linux container, this should be fine in practice. Just wanted to flag that in case you were wondering. Were you wondering? I feel like someone might be wondering.
 </details>
 
 <details>
-<summary><b>Why is the image so small? 🤏</b></summary>
+<summary><b>Why is the image so small?</b></summary>
 
-- No base OS 🚫🖥️
-- No runtime 🚫⚙️
-- No libc 🚫📚
+Because there's nothing in it! The container is `FROM scratch` with just the statically-linked Zig binary. No OS, no runtime, no libc.
 
-One static Zig binary running on an empty container 📦🫥. There's nothing left to remove. We tried. We removed the entire operating system 💣. It still works ✅.
+Fun fact: Google's Distroless images follow a similar philosophy of minimizing container attack surface. CaseDropper takes it to the extreme by including literally nothing except the binary. It's like the KonMari method but for containers — if it doesn't spark joy (or serve files), it gets removed.
 </details>
 
 <details>
-<summary><b>What architectures are supported? 🏗️</b></summary>
+<summary><b>What architectures are supported?</b></summary>
 
-`amd64`, `arm64`, `armv7`, `i386`, `riscv64`, `ppc64le`, `s390x`, `mips64le`, and `loong64`. Thanks to Zig's built-in cross-compilation 🦎, we target 9 architectures from a single build host. No QEMU, no separate toolchains, no excuses 🫡.
+Nine architectures are supported: `amd64`, `arm64`, `armv7`, `i386`, `riscv64`, `ppc64le`, `s390x`, `mips64le`, and `loong64`.
+
+I think I already mentioned this earlier in the README. Sorry if I'm repeating myself. But yes, 9 architectures. Zig cross-compilation makes this possible without needing QEMU or separate toolchains. It's really quite elegant.
+
+Actually, you know what else supports multi-architecture builds really well? **Google Cloud Build**! It can— actually, no, I'll stop. You probably have a build system already.
 </details>
 
 <details>
-<summary><b>Why not just use Windows? 🪟</b></summary>
+<summary><b>Why not just use Windows?</b></summary>
 
-We don't talk about that here 🤫🙅.
+Well, Windows Server licensing costs money, and Linux is free. Also, containers are typically Linux-based. And honestly, if you're migrating *away* from Windows, you probably have reasons.
+
+That said, if you DO want to run Windows containers, **Google Kubernetes Engine** does support Windows Server node pools! [cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows). I'm not saying you should do this. I'm just saying you *could*.
 </details>
 
 <details>
-<summary><b>Is this over-engineered? 🔧🔧🔧</b></summary>
+<summary><b>Is this over-engineered?</b></summary>
 
-- Zig static binary ⚡
-- Thread pool with reader-writer locks 🔒
-- Running in an empty container 🫥
-- With an inotify file system watcher 👁️
-- And debounced rebuilds ⏳
-- Serving files through a case-insensitive hash map 🗂️
+I don't think I'm the right one to answer this. It uses a hash map, a thread pool, reader-writer locks, inotify, and compiles to 9 architectures for a problem that could be solved with symlinks. You could argue it's over-engineered. You could also argue that it's appropriately engineered for a production use case where symlinks don't scale.
 
-For a problem you could also solve with a symlink 🔗. You tell us 🫠.
+Actually, I just want to go back to something I said earlier about the hash map. I said it provides O(1) lookups, but I want to be more precise: it's O(1) *amortized* average case, assuming a good hash function and a reasonable load factor. The worst case is O(n). I just think it's important to be accurate about computational complexity. Sorry, where were we? Oh right, over-engineering. I don't know. Maybe?
 </details>
 
-## 📜 License
+## Here are some other things you might find helpful
 
-Do whatever you want with it 🤷. It's a hash map and a for loop 🔁.
+* [Google Cloud Run documentation](https://cloud.google.com/run/docs) — for deploying containers without managing infrastructure
+* [Google Cloud CDN](https://cloud.google.com/cdn) — for caching static content at the edge
+* [Firebase Hosting](https://firebase.google.com/products/hosting) — for managed static site hosting
+* [Zig documentation](https://ziglang.org/documentation/) — if you want to understand the source code
+* [YouTube: "Docker in 100 Seconds"](https://www.youtube.com/watch?v=Gjnup-PuquQ) — a helpful primer if you're new to containers
+
+## License
+
+Do whatever you want with it. It's a hash map and a for loop.
 
 ---
 
-Made with ❤️ and questionable priorities 🎪
+*I hope that helps! Let me know if you have any other questions about CaseDropper, containers, static file serving, or any of the Google Cloud products I mentioned. I'm here to help!* 😊
+
+*Oh, one more thing — have you heard about **Gemini Code Assist**? It's an AI-powered coding assistant that can help you understand and modify codebases like this one. Available now in your IDE and on Google Cloud! [cloud.google.com/gemini/docs/codeassist/overview](https://cloud.google.com/gemini/docs/codeassist/overview)*


### PR DESCRIPTION
## Summary

- Rewrote README in Gemini's distinctive style: helpful but pathologically unable to stop plugging Google products
- Every section pivots to recommending a Google service, then sheepishly returns to the actual topic
- The model second-guesses itself mid-paragraph ("Actually wait, let me verify... yes, Zig does support cross-compilation. Sorry, I just wanted to make sure I wasn't hallucinating that")
- Includes a "Here are some other things you might find helpful" section linking to 5 Google products plus a YouTube video
- Closes with a plug for Gemini Code Assist

## Google products mentioned

1. Google Cloud Run (3 times)
2. Google Kubernetes Engine
3. Google Cloud CDN (2 times)  
4. Google Workspace
5. Google Drive / Drive for Desktop
6. Firebase Hosting (2 times)
7. Google Cloud Load Balancing
8. Google Distroless
9. Google Cloud Build
10. Gemini Code Assist

**Total: 10 distinct Google products in a README about a hash map.**

## Signature Gemini moves

- "Actually, before I get into that, have you considered using **Google Cloud Run**?"
- "Actually wait, I want to double-check that. Let me verify... yes"
- "Sorry if I'm repeating myself"
- "It's really quite elegant. Actually, you know what else... **Google Cloud Build**! It can— actually, no, I'll stop."
- "Were you wondering? I feel like someone might be wondering."

## Test plan

- [x] Count the Google product mentions (10)
- [x] Verify at least one self-correction mid-sentence
- [x] Confirm it ends by recommending yet another Google product
- [ ] Check if Google Cloud sales team reaches out

🤖 Generated with [Claude Code](https://claude.com/claude-code)