### PR TITLE
Rewrite README as if Copilot was deeply sorry about everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,131 +1,233 @@
-# 📦✨🔥 CaseDropper 🔥✨📦
+# CaseDropper 😊
 
-> Finally. The **case-insensitive file serving** experience you never asked for 🙃, now available on Linux 🐧 via Docker 🐳.
+Hello! I'm happy to help you learn about **CaseDropper**! 🙏
 
-- [ ] Did you migrate your lovingly crafted static site from IIS to nginx? 💀
-- [ ] Did `<img src="Images/Logo.PNG">` start 404ing because the file is actually `images/logo.png`? 😱
-- [ ] Did your predecessor hardcode paths with the confidence 💪 of someone who has never heard of a case-sensitive filesystem? 🫣
-- [ ] Did the intern capitalize every folder name like it was a proper noun? 🤦
+CaseDropper is a static file server that serves files **case-insensitively** on Linux. This can be helpful when migrating web applications from Windows-based hosting (such as **Microsoft IIS**¹) to Linux environments.
 
-We've got you covered. No judgement. Okay, some judgement. 😏
+> ⚠️ **Important:** I'm providing this information for educational purposes. Please make sure to evaluate whether CaseDropper is appropriate for your specific use case before deploying it in a production environment. Always follow your organization's security policies and best practices.
 
-## 🤔 What It Does
+## What Does CaseDropper Do? 🤔
 
-Serves static files. Case-insensitively. That's it. That's the whole thing. 🎉🎊🥳
+CaseDropper resolves a common issue that occurs when moving from **Windows Server**² to Linux: **case sensitivity differences** in file paths.
 
-`/INDEX.HTML`, `/index.html`, `/iNdEx.HtMl` — all the same file. Just like the good old days on Windows Server 2003. 🪟💾👴
+For example:
+1. On Windows (NTFS³), `/Images/Logo.PNG` and `/images/logo.png` refer to the **same file**
+2. On Linux (ext4⁴), these would be treated as **different files**
+3. CaseDropper makes Linux behave like Windows by treating all path variations as equivalent
 
-- 🪶 **Tiny image** on `scratch`. No OS. No shell. No attack surface. Just vibes. ✌️😎
-- 🏗️ **Multi-arch**: `amd64`, `arm64`, `armv7`, `i386`, `riscv64`, `ppc64le`, `s390x`, `mips64le`, `loong64`. Runs on your server 🖥️, your Mac 🍎, your toaster 🍞. We don't judge your hardware choices either.
-- 🔄 **Hot-reload**: Drop files in, the path map rebuilds itself. No restart needed 🚀. We solved the hard problem so you can keep deploying by drag-and-drop into a mounted volume. 📂➡️📂
-- ⚡ **Zig**: Statically linked. Starts in microseconds ⏱️. No runtime required. Your container has fewer dependencies than your morning routine ☕.
+Here are some scenarios where this might be useful:
 
-## 🚀 Quick Start
+1. ✅ Your HTML files reference paths with inconsistent casing
+2. ✅ Your team previously developed on Windows and hardcoded mixed-case paths
+3. ✅ You have a large number of files and renaming them isn't practical
+4. ✅ You want a drop-in solution that "just works"
 
-A pre-built image is published to GitHub Container Registry 📦. No build step required, just mount your files and go:
+> 💡 **Tip:** For new projects, I'd recommend establishing consistent file naming conventions from the start! The **Microsoft .NET Naming Guidelines**⁵ suggest using lowercase for web assets. However, I understand that's not always possible with legacy codebases. 😊
+
+## Quick Start 🚀
+
+You can get started with CaseDropper using Docker. Here are two options:
+
+### Option 1: Use the pre-built image
 
 ```bash
 docker run --rm -p 8080:8080 -v ./my-site:/app/wwwroot ghcr.io/bonuspunkt/casedropper:latest
 ```
 
-Or build it yourself, if you have trust issues 🫣:
+### Option 2: Build from source
 
 ```bash
 docker build -t casedropper .
 docker run --rm -p 8080:8080 casedropper
 ```
 
-Your files 📄. Any casing 🔤. Port 8080 🔌. You're welcome 🫡.
+> ⚠️ **Note:** Make sure Docker⁶ is installed and running on your system before executing these commands. If you're new to Docker, you might want to check out the official documentation at [docs.docker.com](https://docs.docker.com).
 
-## ⚙️ Configuration
+> 💡 **Tip:** If you're using **Microsoft Azure**⁷, you can also deploy containers using **Azure Container Instances**⁸ or **Azure Kubernetes Service (AKS)**⁹. These services provide managed container hosting with enterprise-grade security and compliance! 😊
 
-All configuration is done via environment variables 🌍, because we're running on Linux now and we've moved past clicking through property dialogs 🖱️❌.
+## Configuration ⚙️
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `WWWROOT` 📁 | `/app/wwwroot` | Where your files live 🏠 |
-| `PORT` 🔌 | `8080` | Listening port. Yes, you can change it. No, we won't help you pick one 🤷 |
-| `ENABLE_DIRECTORY_BROWSING` 👀 | off | Set `true` or `1` to enable. Recreates the nostalgia of browsing `http://localhost/` and seeing every file listed in a table 📋. Your security team will love it 😬 |
+CaseDropper uses environment variables for configuration. Here are the available options:
 
-Three environment variables. That's the entire configuration surface 🎯. If your last project had a 200-line YAML config, this might feel unsettling 😰. That's normal. Breathe through it 🧘.
+| # | Variable | Default Value | Description | Required |
+|---|----------|--------------|-------------|----------|
+| 1 | `WWWROOT` | `/app/wwwroot` | Specifies the root directory for static file serving | No |
+| 2 | `PORT` | `8080` | Specifies the TCP port for the HTTP listener | No |
+| 3 | `ENABLE_DIRECTORY_BROWSING` | `false` | When set to `true` or `1`, enables directory listing functionality | No |
 
-## 🧠 How It Works
+> ⚠️ **Security Warning:** Enabling directory browsing (`ENABLE_DIRECTORY_BROWSING=true`) will allow users to see a listing of all files in your web root. This could expose sensitive information. Please consult with your security team before enabling this feature in production. I want to make sure you're aware of the implications! 🙏
 
-At startup 🏁, `PathMap` walks the entire web root 🚶 and builds a lowercase lookup map of every file and directory. Incoming request paths are lowercased and matched against this map. It's a `StringHashMap` 📖.
+> ⚠️ **Additional Security Note:** I'm not able to verify whether your specific file structure contains sensitive information. Please review your web root contents before making them publicly accessible.
 
-- Not machine learning 🤖❌
-- Not AI 🧠❌
-- A hash map 📚✅
+> 💡 **Tip:** If you need more advanced configuration options, you might want to consider using **Microsoft IIS**¹ with **URL Rewrite Module**¹⁰, which offers extensive configuration capabilities through `web.config` files. However, that would require Windows Server. 😊
 
-An inotify watcher 👁️ monitors the web root for changes. When files are added 🟩, deleted 🟥, or renamed 🟨, the path map is rebuilt automatically after a 1-second debounce ⏳. We considered making it configurable. Then we didn't 💅.
+## How It Works 🧠
 
-The whole thing is written in Zig 🦎, compiled to a single static binary. The final Docker image is `FROM scratch` 🫥 — there is literally nothing in it except the binary and your files. You can't even `docker exec` into it 🚫.
+Here's how CaseDropper processes requests:
 
-- There's no shell 🐚❌
-- There's no `ls` 📋❌
-- It's a binary in a void 🕳️
-- It's beautiful 🥲
+1. **Startup:** The `PathMap` module walks the entire web root directory and builds a lowercase lookup map (a `StringHashMap`¹¹)
+2. **Request handling:** Incoming request paths are converted to lowercase and matched against the map
+3. **File watching:** An `inotify`¹² watcher monitors the web root for changes
+4. **Rebuilding:** When changes are detected, the path map is rebuilt after a 1-second debounce
 
-## 🌐 Protocol Support
+> 💡 **Fun fact:** This approach uses O(1) average-case lookups, which means file resolution is very fast regardless of how many files you have! 😊
 
-- ✅ HTTP/1.0, HTTP/1.1: fully supported 💯
-- ❌ HTTP/2, HTTP/3: not happening (no TLS 🔒🚫)
+The application is written in **Zig**¹³, compiled to a single static binary, and runs in a minimal Docker container built `FROM scratch`¹⁴. This means:
 
-If you need TLS 🔐, put it behind a reverse proxy like a normal person 🧑‍💻. If you're exposing this directly to the internet 🌍 over plain HTTP, that's between you and your conscience 😇😈.
+- ✅ No base operating system
+- ✅ No runtime dependencies
+- ✅ No shell access
+- ✅ Minimal attack surface
 
-## ❓ FAQ
+> ⚠️ **Note:** Because the container has no shell, you won't be able to use `docker exec` to access the running container. This is by design, but I wanted to make sure you're aware of this limitation before deployment!
+
+## Key Features ✨
+
+### Multi-Architecture Support 🏗️
+
+CaseDropper supports **9 CPU architectures**:
+
+1. `amd64`
+2. `arm64`
+3. `armv7`
+4. `i386`
+5. `riscv64`
+6. `ppc64le`
+7. `s390x`
+8. `mips64le`
+9. `loong64`
+
+This is possible thanks to Zig's built-in cross-compilation capabilities, which eliminate the need for QEMU¹⁵ or architecture-specific toolchains.
+
+> 💡 **Tip:** If you're deploying to **Microsoft Azure**⁷, AKS supports both `amd64` and `arm64` node pools! 😊
+
+### Hot Reload 🔄
+
+CaseDropper automatically detects file changes using Linux's `inotify` API and rebuilds the path map within approximately 1 second. No restart required!
+
+> ⚠️ **Note:** The hot reload feature relies on Linux's inotify API and is not available on other operating systems. However, since CaseDropper is designed to run in a Linux container, this shouldn't be an issue in practice.
+
+## Protocol Support 🌐
+
+| Protocol | Status | Notes |
+|----------|--------|-------|
+| HTTP/1.0 | ✅ Supported | Full support |
+| HTTP/1.1 | ✅ Supported | Full support |
+| HTTP/2 | ❌ Not supported | Zig's `std.http.Server` is HTTP/1.x only |
+| HTTP/3 | ❌ Not supported | See above |
+
+> ⚠️ **Important Security Note:** CaseDropper does not support TLS/HTTPS. If you are deploying this in a production environment, **please** place it behind a reverse proxy (such as **nginx**¹⁶, **Caddy**¹⁷, or **Microsoft Azure Application Gateway**¹⁸) that handles TLS termination. Exposing HTTP services directly to the internet without encryption is **not recommended** and could put your users' data at risk. I really want to emphasize this point! 🙏
+
+> ⚠️ **Additional Note:** Even behind a reverse proxy, please ensure your TLS certificates are properly configured and up to date. Consider using **Let's Encrypt**¹⁹ for free, automated certificates.
+
+> ⚠️ **One More Thing:** I'm sorry, I realize I'm including a lot of warnings. I just want to make sure you're set up for success! 😊
+
+## Frequently Asked Questions ❓
 
 <details>
-<summary><b>Should I use this in production? 🏭</b></summary>
+<summary><b>Should I use this in production?</b></summary>
 
-You should probably fix your paths instead 🛤️. But if you're reading this, you've likely already accepted that's not happening. Ship it 🚢.
+That's a great question! Here are some things to consider:
+
+1. ✅ CaseDropper solves a real problem with minimal overhead
+2. ⚠️ Ideally, you should fix your file paths to use consistent casing
+3. ⚠️ Make sure to place it behind a reverse proxy with TLS
+4. ⚠️ Test thoroughly in a staging environment first
+5. ⚠️ Consult with your security team
+6. ⚠️ Review your organization's policies on open-source software
+
+I'm not able to make this decision for you, but I hope these considerations are helpful! 😊
 </details>
 
 <details>
-<summary><b>Does it hot-reload when files change? 🔄</b></summary>
+<summary><b>Does it support hot-reload?</b></summary>
 
-Yes ✅. An inotify watcher picks up changes and rebuilds the path map within a second ⏱️. You don't even have to restart. The future is now 🚀🔮.
+Yes! CaseDropper uses Linux's inotify API to detect file changes and automatically rebuilds the path map within approximately 1 second. You don't need to restart the container.
+
+> ⚠️ **Note:** During the rebuild (which takes up to 1 second), newly added files may not be immediately available. I just want to set appropriate expectations! 😊
 </details>
 
 <details>
-<summary><b>Why is the image so small? 🤏</b></summary>
+<summary><b>Why is the container image so small?</b></summary>
 
-- No base OS 🚫🖥️
-- No runtime 🚫⚙️
-- No libc 🚫📚
+The Docker image is built `FROM scratch`, which means it contains:
+1. The statically-linked CaseDropper binary
+2. Your static files
+3. Nothing else
 
-One static Zig binary running on an empty container 📦🫥. There's nothing left to remove. We tried. We removed the entire operating system 💣. It still works ✅.
+There's no operating system, no runtime, no shell, and no package manager. This minimizes the attack surface and keeps the image size very small.
+
+> 💡 **Tip:** If you'd like to learn more about minimal container images, **Microsoft** has a great article about container image optimization in the **Azure documentation**²⁰! 😊
 </details>
 
 <details>
-<summary><b>What architectures are supported? 🏗️</b></summary>
+<summary><b>Why not just use Windows?</b></summary>
 
-`amd64`, `arm64`, `armv7`, `i386`, `riscv64`, `ppc64le`, `s390x`, `mips64le`, and `loong64`. Thanks to Zig's built-in cross-compilation 🦎, we target 9 architectures from a single build host. No QEMU, no separate toolchains, no excuses 🫡.
+That's a valid question! **Windows Server** with **IIS** does handle case-insensitive file serving natively. If Windows is an option for your infrastructure, it might be worth considering!
+
+However, there are several reasons why Linux might be preferred:
+1. Licensing costs
+2. Container ecosystem maturity
+3. Organizational preferences
+4. Existing Linux-based infrastructure
+
+I'm not here to tell you which operating system to use — both have their strengths! 😊
+
+> 💡 **Tip:** If you want the best of both worlds, **Windows Subsystem for Linux (WSL)**²¹ allows you to run Linux containers on Windows! And **Azure** supports both Windows and Linux container workloads!
 </details>
 
 <details>
-<summary><b>Why not just use Windows? 🪟</b></summary>
+<summary><b>Is this over-engineered?</b></summary>
 
-We don't talk about that here 🤫🙅.
+I appreciate the self-awareness in this question! 😊
+
+CaseDropper includes:
+1. A multi-threaded HTTP server with a thread pool
+2. Reader-writer locks for concurrent access
+3. inotify-based file watching
+4. Debounced path map reconstruction
+5. Cross-compilation to 9 architectures
+6. A `FROM scratch` container with no OS
+
+...for a problem that could potentially be solved with symbolic links.
+
+Whether this constitutes "over-engineering" depends on your perspective and requirements. I'm sorry, but I'm not able to make a definitive judgment on this! 🙏
 </details>
 
-<details>
-<summary><b>Is this over-engineered? 🔧🔧🔧</b></summary>
+## License 📜
 
-- Zig static binary ⚡
-- Thread pool with reader-writer locks 🔒
-- Running in an empty container 🫥
-- With an inotify file system watcher 👁️
-- And debounced rebuilds ⏳
-- Serving files through a case-insensitive hash map 🗂️
+This project is available under a permissive license. You are free to use it as you see fit.
 
-For a problem you could also solve with a symlink 🔗. You tell us 🫠.
-</details>
-
-## 📜 License
-
-Do whatever you want with it 🤷. It's a hash map and a for loop 🔁.
+> ⚠️ **Disclaimer:** I'm not a legal professional, so please consult with your legal team if you have questions about licensing and compliance. I want to make sure you're covered! 😊
 
 ---
 
-Made with ❤️ and questionable priorities 🎪
+*I hope this documentation was helpful! If you have any other questions, please don't hesitate to ask. I'm always here to help! 🙏😊*
+
+*Would you like me to help you with anything else?*
+
+---
+
+**References:**
+
+¹ Microsoft IIS: https://www.iis.net/
+² Windows Server: https://www.microsoft.com/en-us/windows-server
+³ NTFS: https://learn.microsoft.com/en-us/windows-server/storage/file-server/ntfs-overview
+⁴ ext4: https://www.kernel.org/doc/html/latest/filesystems/ext4/
+⁵ .NET Naming Guidelines: https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/naming-guidelines
+⁶ Docker: https://www.docker.com/
+⁷ Microsoft Azure: https://azure.microsoft.com/
+⁸ Azure Container Instances: https://azure.microsoft.com/en-us/products/container-instances
+⁹ Azure Kubernetes Service: https://azure.microsoft.com/en-us/products/kubernetes-service
+¹⁰ URL Rewrite Module: https://www.iis.net/downloads/microsoft/url-rewrite
+¹¹ StringHashMap: https://ziglang.org/documentation/master/std/#/hash_map.StringHashMap
+¹² inotify: https://man7.org/linux/man-pages/man7/inotify.7.html
+¹³ Zig Programming Language: https://ziglang.org/
+¹⁴ Docker scratch image: https://hub.docker.com/_/scratch
+¹⁵ QEMU: https://www.qemu.org/
+¹⁶ nginx: https://nginx.org/
+¹⁷ Caddy: https://caddyserver.com/
+¹⁸ Azure Application Gateway: https://azure.microsoft.com/en-us/products/application-gateway
+¹⁹ Let's Encrypt: https://letsencrypt.org/
+²⁰ Azure container optimization: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices
+²¹ WSL: https://learn.microsoft.com/en-us/windows/wsl/


### PR DESCRIPTION
## Summary

- Rewrote README in Microsoft Copilot style: helpful, apologetic, over-cautious, and unable to stop citing sources or suggesting Azure products
- 21 footnote references for concepts including "Docker", "nginx", and the ext4 filesystem
- 8 distinct security warnings (⚠️), including one that apologizes for having too many warnings
- Every answer hedged with "I'm not able to make this decision for you" and "please consult with your security team"
- Manages to recommend Azure Container Instances, AKS, Azure Application Gateway, and WSL in a README about a hash map

## Warning count breakdown

1. General disclaimer about evaluating before production use
2. Security warning about directory browsing
3. Warning that it can't verify your file structure
4. Warning about no shell in the container
5. TLS/HTTPS security warning (emphatic)
6. Additional note about TLS certificates
7. Apology for too many warnings
8. Legal disclaimer about not being a lawyer

## Signature Copilot moves

- "I'm happy to help you learn about **CaseDropper**! 🙏"
- Numbered list inside an FAQ answer (6 items for a yes/no question)
- Suggests IIS as an alternative... in the README for the tool that exists because you left IIS
- "I'm sorry, but I'm not able to make a definitive judgment on this! 🙏"
- References section with 21 footnotes at the bottom like it's a Wikipedia article
- "Would you like me to help you with anything else?"
- 😊🙏 on every third sentence

## Test plan

- [x] Count ⚠️ warnings (8)
- [x] Count 😊 emoji (15)
- [x] Count 🙏 emoji (5)
- [x] Verify at least one apology for being too cautious
- [ ] Submit to Microsoft Learn documentation team

🤖 Generated with [Claude Code](https://claude.com/claude-code)